### PR TITLE
Added "Blueprints" parenthesis for Content Templates

### DIFF
--- a/versioned_docs/version-10.x/06.reference/03.handlernames.md
+++ b/versioned_docs/version-10.x/06.reference/03.handlernames.md
@@ -26,7 +26,7 @@ MediaTypeHandler | Settings | Media Types.
 MemberTypeHandler | Settings | Member Types.
 TemplateHandler | Settings | Templates.
 ContentHandler | Content | Handles content items.
-ContentTemplateHandler | Content | Content Templates. 
+ContentTemplateHandler | Content | Content Templates (Blueprints). 
 DictionaryHandler | Content | Dictionary items.
 DomainHandler | Content | "Culture and Hostname" settings for content.
 MediaHandler | Content | Media items.


### PR DESCRIPTION
Maybe I should just have read the handler names one by one, but I couldn't figure out the correct name for **Blueprints**, since that is what the handler is called in the UI.

I found the correct alias by inspecting the DOM of the uSync dashboard, and then going for `angular.element($0).scope()`. Maybe not the smoothest path.

I didn't think to search for "content templates" instead, so by adding `(Blueprints)` to the description, others may hopefully be better at finding the correct handler name than I was.