### PR TITLE
Fix rows for DataType specific handler settings

### DIFF
--- a/usync/01.uSync/40.reference/02.handlers.md
+++ b/usync/01.uSync/40.reference/02.handlers.md
@@ -96,9 +96,8 @@ Content/Media | Include | "" | Content Path | Path to a content item include.
 &nbsp;| DoNotSerialize | "" | PropertyName | Names of content/media properties not to serialize as part of a sync <br/> *(Added [uSync 9.1+ #289](https://github.com/KevinJump/uSync/issues/289))*
 &nbsp;|IncludeContentTypes| "" | ContentTypes | List of content types to include, when this value is set *ONLY* these content types will be included in any sync <br/> *(Added [uSync 10.3+ #419](https://github.com/KevinJump/uSync/issues/419)))*
 &nbsp;|ExcludeContentTypes| "" | ContentTypes | List of content types to exclude, When using this setting all other content types are synced and any in this list are ignored. <br/> *(Added [uSync 10.3+ #419](https://github.com/KevinJump/uSync/issues/419)))*
-
-DataTypes | NoConfigNames | String | List of datatypes by name that you don't want to import the configuration for.
-&nbsp;| NoConfigEditors | String | List of editor aliases of items you don't want the configuration to be imported for.
+DataTypes | NoConfigNames | "" | String | List of datatypes by name that you don't want to import the configuration for.
+&nbsp;| NoConfigEditors | "" | String | List of editor aliases of items you don't want the configuration to be imported for.
 
 #### Example 
 These settings are often set on individual handlers for example, the configuration below would not import trashed items, and exclude any content in the the `Home/Testing` content tree.

--- a/versioned_docs/version-10.x/06.reference/02.handlers.md
+++ b/versioned_docs/version-10.x/06.reference/02.handlers.md
@@ -96,9 +96,8 @@ Content/Media | Include | "" | Content Path | Path to a content item include.
 &nbsp;| DoNotSerialize | "" | PropertyName | Names of content/media properties not to serialize as part of a sync <br/> *(Added [uSync 9.1+ #289](https://github.com/KevinJump/uSync/issues/289))*
 &nbsp;|IncludeContentTypes| "" | ContentTypes | List of content types to include, when this value is set *ONLY* these content types will be included in any sync <br/> *(Added [uSync 10.3+ #419](https://github.com/KevinJump/uSync/issues/419)))*
 &nbsp;|ExcludeContentTypes| "" | ContentTypes | List of content types to exclude, When using this setting all other content types are synced and any in this list are ignored. <br/> *(Added [uSync 10.3+ #419](https://github.com/KevinJump/uSync/issues/419)))*
-
-DataTypes | NoConfigNames | String | List of datatypes by name that you don't want to import the configuration for.
-&nbsp;| NoConfigEditors | String | List of editor aliases of items you don't want the configuration to be imported for.
+DataTypes | NoConfigNames | "" | String | List of datatypes by name that you don't want to import the configuration for.
+&nbsp;| NoConfigEditors | "" | String | List of editor aliases of items you don't want the configuration to be imported for.
 
 #### Example 
 These settings are often set on individual handlers for example, the configuration below would not import trashed items, and exclude any content in the the `Home/Testing` content tree.

--- a/versioned_docs/version-12.x/01.uSync/40.reference/02.handlers.md
+++ b/versioned_docs/version-12.x/01.uSync/40.reference/02.handlers.md
@@ -96,9 +96,8 @@ Content/Media | Include | "" | Content Path | Path to a content item include.
 &nbsp;| DoNotSerialize | "" | PropertyName | Names of content/media properties not to serialize as part of a sync <br/> *(Added [uSync 9.1+ #289](https://github.com/KevinJump/uSync/issues/289))*
 &nbsp;|IncludeContentTypes| "" | ContentTypes | List of content types to include, when this value is set *ONLY* these content types will be included in any sync <br/> *(Added [uSync 10.3+ #419](https://github.com/KevinJump/uSync/issues/419)))*
 &nbsp;|ExcludeContentTypes| "" | ContentTypes | List of content types to exclude, When using this setting all other content types are synced and any in this list are ignored. <br/> *(Added [uSync 10.3+ #419](https://github.com/KevinJump/uSync/issues/419)))*
-
-DataTypes | NoConfigNames | String | List of datatypes by name that you don't want to import the configuration for.
-&nbsp;| NoConfigEditors | String | List of editor aliases of items you don't want the configuration to be imported for.
+DataTypes | NoConfigNames | "" | String | List of datatypes by name that you don't want to import the configuration for.
+&nbsp;| NoConfigEditors | "" | String | List of editor aliases of items you don't want the configuration to be imported for.
 
 #### Example 
 These settings are often set on individual handlers for example, the configuration below would not import trashed items, and exclude any content in the the `Home/Testing` content tree.


### PR DESCRIPTION
Handler specific settings table is hard to read for datatypes.

Before
![image](https://github.com/Jumoo/jumoo-docs/assets/2056399/f65a1b19-7876-4e0a-8441-b1274154bd7a)

After
![image](https://github.com/Jumoo/jumoo-docs/assets/2056399/d7d93cfd-7a42-476c-8c90-ce656eb51b2e)
