### PR TITLE
Update 50.flat.md

### DIFF
--- a/versioned_docs/version-13.x/01.uSync/20.guides/50.flat.md
+++ b/versioned_docs/version-13.x/01.uSync/20.guides/50.flat.md
@@ -19,6 +19,7 @@ The default value for this settings is **true.**
         "Default" : {
             "HandlerDefaults": {
                "UseFlatStructure": false
+            }
         }
     }
 }


### PR DESCRIPTION
Fix invalid JSON by adding a missing closing bracket.

Note: this should also be applied to all the other `50.flat.md` files for Umbraco versions 10/15/16 they all have this syntax error. I'm using the GitHub UI right now for this PR and cannot easily add them all it seems so consider updating those yourselves, sorry.